### PR TITLE
feat: add PostgreSQL backup service with cron job

### DIFF
--- a/db_backup/Dockerfile
+++ b/db_backup/Dockerfile
@@ -1,0 +1,18 @@
+FROM postgres:16
+
+# Install cron
+RUN apt-get update && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+
+# Copy script
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh
+
+# Cron job (every day at 2 AM)
+RUN echo "0 2 * * * root . /etc/environment && /usr/local/bin/backup.sh >> /var/log/cron.log 2>&1" \
+    > /etc/cron.d/pg_backup
+
+
+# Apply cron permissions
+RUN chmod 0644 /etc/cron.d/pg_backup && crontab /etc/cron.d/pg_backup
+
+CMD ["cron", "-f"]

--- a/db_backup/backup.sh
+++ b/db_backup/backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+DATE=$(date +"%Y%m%d_%H%M%S")
+
+# Make sure backup dir exists
+mkdir -p "/backups"
+
+# Run pg_dump
+pg_dump "postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" \
+  | gzip > "/backups/${DB_NAME}_${DATE}.sql.gz"
+
+# Optional: remove old backups (keep last 7 days)
+find "/backups" -type f -mtime +7 -delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,16 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./db:/docker-entrypoint-initdb.d
 
+  db_backup:
+    build: ./db_backup
+    container_name: border_scraper_db_backup
+    restart: always
+    volumes:
+      - .env:/etc/environment:ro
+      - .${BACKUP_DIR}:/backups
+    depends_on:
+      - db
+
   app:
     build:
       context: ./scraper
@@ -49,3 +59,4 @@ services:
 
 volumes:
   postgres_data:
+  postgres_data_test:


### PR DESCRIPTION
## Add Automated PostgreSQL Backup Service

### Summary
This PR introduces a new backup service for the PostgreSQL database using a dedicated container with a cron job.

### Changes
- Added `db_backup/backup.sh` script for daily backups.
- Added `db_backup/Dockerfile` to build the backup container with cron support.
- Updated `docker-compose.yml` to include the new `db_backup` service and required volumes.

### Notes
- Backups are stored in the specified backup directory and rotated (keeps last 7 days).
- Environment variables are loaded from `.env` for database connection.