### PR TITLE
Add backup-aware Postgres initialization script and update docker-com…

### DIFF
--- a/db/restore-or-init.sh
+++ b/db/restore-or-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+BACKUP_DIR="/backups"
+LATEST_BACKUP=$(ls -1t "$BACKUP_DIR"/*.sql.gz 2>/dev/null | head -n 1)
+
+# Wait until Postgres is ready to accept connections
+until pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /dev/null 2>&1; do
+    echo "Waiting for postgres to be ready..."
+    sleep 2
+done
+
+if [ -n "$LATEST_BACKUP" ]; then
+    echo ">>> Found backup: $LATEST_BACKUP"
+    echo ">>> Restoring into database: $POSTGRES_DB"
+    gunzip -c "$LATEST_BACKUP" | psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+    echo ">>> Restore finished. Skipping schema initialization."
+    # Prevent execution of *.sql files (since restore already handled schema + data)
+    mv /docker-entrypoint-initdb.d/*.sql /tmp/ 2>/dev/null || true
+else
+    echo ">>> No backup found, proceeding with schema initialization."
+    # Leave .sql files in place → they’ll run automatically
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     container_name: border_scraper_db
     restart: always
     environment:
-      TZ: Europe/Vilnius
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_NAME}
@@ -13,6 +12,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db:/docker-entrypoint-initdb.d
+      - ./db_backup/backups:/backups
 
   db_backup:
     build: ./db_backup
@@ -59,4 +59,3 @@ services:
 
 volumes:
   postgres_data:
-  postgres_data_test:


### PR DESCRIPTION
…pose

- Add db/restore-or-init.sh to restore from latest backup if available, or initialize schema if not.
- Mount db_backup/backups as /backups in db service for restore script access.
- Ensure .sql schema files are skipped if a backup is restored.
- No changes to application or backup container logic.